### PR TITLE
Fix IFace IdentifyAsync to return List of IdentifyResult

### DIFF
--- a/source/FaceClientSDK.Tests/FaceTests.cs
+++ b/source/FaceClientSDK.Tests/FaceTests.cs
@@ -134,7 +134,7 @@ namespace FaceClientSDK.Tests
             try
             {
                 detectResult = await ApiReference.Instance.Face.DetectAsync(faceAPISettingsFixture.TestGroupImageUrl, "age,gender,headPose,smile,facialHair,glasses,emotion,hair,makeup,occlusion,accessories,blur,exposure,noise", true, true);
-                if (detectResult.Count>0)
+                if (detectResult.Count > 0)
                 {
                     groupResult = await ApiReference.Instance.Face.GroupAsync((from result in detectResult select result.faceId).ToArray());
                 }
@@ -145,6 +145,25 @@ namespace FaceClientSDK.Tests
             }
 
             Assert.True(groupResult != null);
+        }
+
+        [Fact]
+        public async void IdentifyAsyncTest()
+        {
+            List<IdentifyResult> result = null;
+            var identifier = System.Guid.NewGuid().ToString();
+            string[] faceIds = new[] { "" };
+
+            try
+            {
+                result = await ApiReference.Instance.Face.IdentifyAsync(identifier, faceIds, 1, 0.5);
+            }
+            catch
+            {
+                throw;
+            }
+
+            Assert.True(result != null);
         }
     }
 }

--- a/source/FaceClientSDK/ApiReference.cs
+++ b/source/FaceClientSDK/ApiReference.cs
@@ -226,7 +226,7 @@ namespace FaceClientSDK
 
         }
 
-        public async Task<DomainFace.IdentifyResult> IdentifyAsync(string largePersonGroupId, string[] faceIds, int maxNumOfCandidatesReturned, double confidenceThreshold)
+        public async Task<List<DomainFace.IdentifyResult>> IdentifyAsync(string largePersonGroupId, string[] faceIds, int maxNumOfCandidatesReturned, double confidenceThreshold)
         {
             dynamic body = new JObject();
 
@@ -246,11 +246,11 @@ namespace FaceClientSDK
                 client.DefaultRequestHeaders.Add("Ocp-Apim-Subscription-Key", ApiReference.FaceAPIKey);
                 var response = await client.PostAsync($"https://{ApiReference.FaceAPIZone}.api.cognitive.microsoft.com/face/v1.0/identify", queryString);
 
-                DomainFace.IdentifyResult result = null;
+                List<DomainFace.IdentifyResult> result = null;
                 if (response.IsSuccessStatusCode)
                 {
                     var json = await response.Content.ReadAsStringAsync();
-                    result = JsonConvert.DeserializeObject<DomainFace.IdentifyResult>(json);
+                    result = JsonConvert.DeserializeObject<List<DomainFace.IdentifyResult>>(json);
                 }
                 else
                 {

--- a/source/FaceClientSDK/Interfaces/IFace.cs
+++ b/source/FaceClientSDK/Interfaces/IFace.cs
@@ -14,6 +14,6 @@ namespace FaceClientSDK.Interfaces
 
         Task<VerifyResult> VerifyAsync(string faceId1, string faceId2, string faceId, string personGroupId, string largePersonGroupId, string personId);
 
-        Task<IdentifyResult> IdentifyAsync(string largePersonGroupId, string[] faceIds, int maxNumOfCandidatesReturned, double confidenceThreshold);
+        Task<List<IdentifyResult>> IdentifyAsync(string largePersonGroupId, string[] faceIds, int maxNumOfCandidatesReturned, double confidenceThreshold);
     }
 }


### PR DESCRIPTION
The current IdentifyAsync method of the IFace Interface returns a single IdentifyResult. It should return a collection of IdentifyResult. With the current implementation an exception is thrown.

I've change the method signature to the following:

Task<List<IdentifyResult>> IdentifyAsync(string largePersonGroupId, string[] faceIds, int maxNumOfCandidatesReturned, double confidenceThreshold);

